### PR TITLE
[oneds-4283] Publicly host 1fe widget, shell, and library assets on akamai

### DIFF
--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -72,4 +72,4 @@ jobs:
         run: |
           set -e
           echo "Purging all assets with cache tag using akamai-purge..."
-          akamai purge --edgerc .edgerc cachePurgeByType --tag 1fe
+          akamai purge --edgerc .edgerc --type tag 1fe

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -51,30 +51,12 @@ jobs:
           sudo apt-get install -y rsync
           rsync --version || { echo "rsync installation failed"; exit 1; }
 
-      - name: Validate Akamai configuration files
-        run: |
-          set -e
-          if [ ! -f ~/.edgerc ]; then
-            echo "Error: ~/.edgerc file is missing."
-            exit 1
-          if [ ! -f ~/auth ]; then
-            echo "Error: ~/auth file is missing."
-            exit 1
-          fi
-          echo "Akamai configuration files are valid."
-
       - name: Upload config files to NetStorage
         run: |
           cp common-configs/integration.json live.json && akamai netstorage upload live.json --directory integration/configs --config ~/auth && rm live.json
           cp common-configs/stage.json live.json && akamai netstorage upload live.json --directory stage/configs --config ~/auth && rm live.json
           cp common-configs/demo.json live.json && akamai netstorage upload live.json --directory demo/configs --config ~/auth && rm live.json
-          cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json1``
-
-      - name: Install rsync
-        run: |
-          set -e
-          sudo apt-get update
-          sudo apt-get install -y rsync
+          cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json1
 
       - name: Sync directories to NetStorage using rsync
         run: |

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main  # Trigger on PRs targeting the main branch
 
+# trigger
+
 jobs:
   upload-and-purge:
     runs-on: ubuntu-latest

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -44,33 +44,51 @@ jobs:
           host = 1fe-nsu.akamaihd.net
           cpcode = 1800003" > ~/auth
 
+      - name: Install rsync
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y rsync
+          rsync --version || { echo "rsync installation failed"; exit 1; }
+
+      - name: Validate Akamai configuration files
+        run: |
+          set -e
+          if [ ! -f ~/.edgerc ]; then
+            echo "Error: ~/.edgerc file is missing."
+            exit 1
+          if [ ! -f ~/auth ]; then
+            echo "Error: ~/auth file is missing."
+            exit 1
+          fi
+          echo "Akamai configuration files are valid."
+
       - name: Upload config files to NetStorage
         run: |
           cp common-configs/integration.json live.json && akamai netstorage upload live.json --directory integration/configs --config ~/auth && rm live.json
           cp common-configs/stage.json live.json && akamai netstorage upload live.json --directory stage/configs --config ~/auth && rm live.json
           cp common-configs/demo.json live.json && akamai netstorage upload live.json --directory demo/configs --config ~/auth && rm live.json
-          cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json
+          cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json1``
 
-      - name: Akamai upload help
+      - name: Install rsync
         run: |
           set -e
-          akamai netstorage upload --help
-          akamai purge invalidate --help
+          sudo apt-get update
+          sudo apt-get install -y rsync
 
-      - name: Upload integration, development, and production folders to NetStorage
+      - name: Sync directories to NetStorage using rsync
         run: |
           set -e
           for folder in integration development production; do
-            find "$folder" -type f | while read file; do
-              echo "Uploading $file..."
-              akamai netstorage upload "$file" --directory "$(dirname $file)" --config ~/auth || echo "Failed to upload $file"
-            done
+            echo "Syncing $folder to NetStorage..."
+            rsync -av --delete "$folder/" "user@1fe-nsu.akamaihd.net::$folder" --password-file=~/auth || echo "Failed to sync $folder"
           done
-          
-      - name: Purge assets to reset cache
+
+      - name: Purge all assets with cache tag
         run: |
           set -e
-          akamai purge invalidate https://1fe-a.akamaihd.net/integration/configs/live.json https://1fe-a.akamaihd.net/stage/configs/live.json https://1fe-a.akamaihd.net/demo/configs/live.json https://1fe-a.akamaihd.net/production/configs/live.json || echo "Failed to purge config files"
+          echo "Purging all assets with cache tag '1fe'..."
+          akamai purge invalidate --tag 1fe || echo "Failed to purge assets with cache tag '1fe'"
 
       - name: Generate list of files to purge
         run: |

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -67,9 +67,9 @@ jobs:
           for folder in integration development production; do
             find "$folder" -type f | while read file; do
               relative_path="${file#$folder/}"  # Get the relative path of the file
-              destination_dir="$folder"  # Use only the folder name as the destination directory
-              echo "Uploading $file to $destination_dir/$relative_path..."
-              akamai netstorage upload "$file" --directory "$destination_dir/$relative_path" --config ~/auth || echo "Failed to upload $file"
+              destination_dir="$folder/${relative_path%/*}"  # Use the folder name and the parent directory of the file
+              echo "Uploading $file to $destination_dir..."
+              akamai netstorage upload "$file" --directory "$destination_dir" --config ~/auth || echo "Failed to upload $file"
             done
           done
 

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - main  # Trigger on PRs targeting the main branch
-    #paths:
-    #  - common-configs/**
 
 jobs:
   upload-and-purge:
@@ -27,20 +25,45 @@ jobs:
           akamai install netstorage
           akamai install purge
           
-          set -e
           echo "[ccu]
           client_secret = ${{ secrets.AKAMAI_API_CLIENT_SECRET }}
           host = ${{ secrets.AKAMAI_API_CLIENT_HOST }}
           access_token = ${{ secrets.AKAMAI_API_CLIENT_ACCESS_TOKEN }}
           client_token = ${{ secrets.AKAMAI_API_CLIENT_CLIENT_TOKEN }}" > ~/.edgerc
 
-          set -e
           echo "[default]
           key = ${{ secrets.AKAMAI_NS_UPLOAD_ACCOUNT_KEY }}
           id = 1fe
           group = 1FE
           host = 1fe-nsu.akamaihd.net
           cpcode = 1800003" > ~/auth
+
+      - name: Install rsync
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y rsync
+          rsync --version || { echo "rsync installation failed"; exit 1; }
+
+      - name: Validate rsync password file
+        run: |
+          set -e
+          if [ ! -f ~/auth ]; then
+            echo "Error: Password file ~/auth is missing."
+            exit 1
+          fi
+          echo "Password file exists and is accessible."
+
+      - name: Validate and set permissions for rsync password file
+        run: |
+          set -e
+          PASSWORD_FILE="$HOME/auth"
+          if [ ! -f "$PASSWORD_FILE" ]; then
+            echo "Error: Password file $PASSWORD_FILE is missing."
+            exit 1
+          fi
+          chmod 600 "$PASSWORD_FILE"
+          echo "Password file permissions set to 600."
 
       - name: Upload config files to NetStorage
         run: |
@@ -49,34 +72,26 @@ jobs:
           cp common-configs/demo.json live.json && akamai netstorage upload live.json --directory demo/configs --config ~/auth && rm live.json
           cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json
 
-      - name: Debug upload paths
+      - name: Sync directories to NetStorage using rsync
         run: |
           set -e
+
+          akamai_ns_rsync_password = ${{ secrets.AKAMAI_NS_RSYNC_PASSWORD }}
+          PASSWORD_FILE="$HOME/auth"
+          echo "$akamai_ns_rsync_password" > "$PASSWORD_FILE"
+          chmod 600 "$PASSWORD_FILE"
+          
+          RSYNC_USER="1fe"  # Replace with the correct username
           for folder in integration development production; do
-            find "$folder" -type f | while read file; do
-              relative_path="${file#$folder/}"
-              echo "Debug: Uploading $file to $folder/$relative_path"
-            done
+            echo "Syncing $folder to NetStorage..."
+            timeout 600 rsync -avvv --debug=ALL4 --progress --delete "$folder/" "$RSYNC_USER@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
           done
 
-      - name: Upload integration, development, and production folders to NetStorage
+      - name: Purge all assets with cache tag
         run: |
           set -e
-          for folder in integration development production; do
-            find "$folder" -type f | while read file; do
-              file_name="${file##*/}"  # Extract just the file name
-              destination_dir="${file%/*}"  # Extract the directory path minus the file name
-              echo "Uploading $file_name to $destination_dir..."
-              cp "$file" "$file_name" && \
-              akamai netstorage upload "$file_name" --directory "$destination_dir" --config ~/auth && \
-              rm "$file_name" || echo "Failed to upload $file_name"
-            done
-          done
-
-      - name: Purge assets to reset cache
-        run: |
-          set -e
-          akamai purge invalidate https://1fe-a.akamaihd.net/integration/configs/live.json https://1fe-a.akamaihd.net/stage/configs/live.json https://1fe-a.akamaihd.net/demo/configs/live.json https://1fe-a.akamaihd.net/production/configs/live.json || echo "Failed to purge config files"
+          echo "Purging all assets with cache tag '1fe'..."
+          akamai purge invalidate --tag 1fe || echo "Failed to purge assets with cache tag '1fe'"
 
       - name: Generate list of files to purge
         run: |
@@ -87,7 +102,7 @@ jobs:
           echo "Files to purge:"
           cat files_to_purge.txt
 
-      - name: Purge uploaded files from Akamai cache
+      - name: Purge individual files from Akamai cache
         run: |
           set -e
           while read file; do

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -57,7 +57,7 @@ jobs:
           for folder in integration development production; do
             find "$folder" -type f | while read file; do
               echo "Uploading $file..."
-              akamai --debug netstorage upload "$file" --directory "$(dirname $file)" --config ~/auth || echo "Failed to upload $file"
+              akamai netstorage upload "$file" --directory "$(dirname $file)" --config ~/auth || echo "Failed to upload $file"
             done
           done
           
@@ -65,9 +65,6 @@ jobs:
         run: |
           set -e
           akamai purge invalidate https://1fe-a.akamaihd.net/integration/configs/live.json https://1fe-a.akamaihd.net/stage/configs/live.json https://1fe-a.akamaihd.net/demo/configs/live.json https://1fe-a.akamaihd.net/production/configs/live.json || echo "Failed to purge config files"
-          for folder in integration development production; do
-            akamai purge invalidate "https://1fe-a.akamaihd.net/$folder/*" || echo "Failed to purge folder $folder"
-          done
 
       - name: Generate list of files to purge
         run: |

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -7,10 +7,6 @@ on:
   pull_request:
     branches:
       - main  # Trigger on PRs targeting the main branch
-    #paths:
-    #  - common-configs/**
-
-# test
 
 jobs:
   upload-and-purge:
@@ -39,7 +35,7 @@ jobs:
           key = ${{ secrets.AKAMAI_NS_UPLOAD_ACCOUNT_KEY }}
           id = 1fe
           group = 1FE
-          host = 1fe-nsu.akamaihd.net
+          host = 1fe.rsync.upload.akamai.com
           cpcode = 1800003" > ~/auth
 
       - name: Install rsync
@@ -70,7 +66,7 @@ jobs:
           set -e
           for folder in integration development production; do
             echo "Syncing $folder to NetStorage..."
-            timeout 120 rsync -avvv --progress --delete "$folder/" "user@1fe-nsu.akamaihd.net::$folder" --password-file=~/auth || echo "Failed to sync $folder"
+            timeout 600 rsync -avvv --progress --delete "$folder/" "user@1fe.rsync.upload.akamai.com::$folder" --password-file=~/auth || echo "Failed to sync $folder"
           done
 
       - name: Purge all assets with cache tag

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -53,19 +53,20 @@ jobs:
 
       - name: Upload integration, development, and production folders to NetStorage
         run: |
+          set -e
           for folder in integration development production; do
             find "$folder" -type f | while read file; do
               echo "Uploading $file..."
-              akamai netstorage upload "$file" --directory "$(dirname $file)" --config ~/auth
+              akamai --debug netstorage upload "$file" --directory "$(dirname $file)" --config ~/auth || echo "Failed to upload $file"
             done
           done
           
       - name: Purge assets to reset cache
         run: |
           set -e
-          akamai purge invalidate https://1fe-a.akamaihd.net/integration/configs/live.json https://1fe-a.akamaihd.net/stage/configs/live.json https://1fe-a.akamaihd.net/demo/configs/live.json https://1fe-a.akamaihd.net/production/configs/live.json
+          akamai purge invalidate https://1fe-a.akamaihd.net/integration/configs/live.json https://1fe-a.akamaihd.net/stage/configs/live.json https://1fe-a.akamaihd.net/demo/configs/live.json https://1fe-a.akamaihd.net/production/configs/live.json || echo "Failed to purge config files"
           for folder in integration development production; do
-            akamai purge invalidate "https://1fe-a.akamaihd.net/$folder/*"
+            akamai purge invalidate "https://1fe-a.akamaihd.net/$folder/*" || echo "Failed to purge folder $folder"
           done
 
       - name: Generate list of files to purge
@@ -78,8 +79,9 @@ jobs:
 
       - name: Purge individual files from Akamai cache
         run: |
+          set -e
           while read file; do
             url="https://1fe-a.akamaihd.net/$file"
             echo "Purging $url..."
-            akamai purge invalidate "$url"
+            akamai purge invalidate "$url" || echo "Failed to purge $url"
           done < files_to_purge.txt

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -78,16 +78,19 @@ jobs:
         run: |
           set -e
 
+          # Retrieve the rsync password from secrets and write it to the password file
           akamai_ns_rsync_password=${{ secrets.AKAMAI_NS_RSYNC_PASSWORD }}
           PASSWORD_FILE="$HOME/auth"
           echo "$akamai_ns_rsync_password" > "$PASSWORD_FILE"
           chmod 600 "$PASSWORD_FILE"
 
+          # Define the rsync user
           RSYNC_USER="1fe"  # Replace with the correct username
+
+          # Sync each folder to NetStorage
           for folder in integration development production; do
             echo "Syncing $folder to NetStorage..."
-            
-          timeout 600 rsync -avvv --debug=ALL4 --progress "$folder/" "$RSYNC_USER@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
+            timeout 600 rsync -avvv --progress --delete "$folder/" "$RSYNC_USER@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
           done
 
       - name: Purge all assets with cache tag

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - main  # Trigger on PRs targeting the main branch
 
-# trigger
-
 jobs:
   upload-and-purge:
     runs-on: ubuntu-latest
@@ -78,9 +76,10 @@ jobs:
         run: |
           set -e
           PASSWORD_FILE="$HOME/auth"
+          RSYNC_USER="1fe"  # Replace with the correct username
           for folder in integration development production; do
             echo "Syncing $folder to NetStorage..."
-            timeout 600 rsync -avvv --progress --delete "$folder/" "user@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
+            timeout 600 rsync -avvv --debug=ALL4 --progress --delete "$folder/" "$RSYNC_USER@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
           done
 
       - name: Purge all assets with cache tag

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -67,3 +67,19 @@ jobs:
           for folder in integration development production; do
             akamai purge invalidate "https://1fe-a.akamaihd.net/$folder/*"
           done
+
+      - name: Generate list of files to purge
+        run: |
+          for folder in integration development production; do
+            find "$folder" -type f >> files_to_purge.txt
+          done
+          echo "Files to purge:"
+          cat files_to_purge.txt
+
+      - name: Purge individual files from Akamai cache
+        run: |
+          while read file; do
+            url="https://1fe-a.akamaihd.net/$file"
+            echo "Purging $url..."
+            akamai purge invalidate "$url"
+          done < files_to_purge.txt

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -72,4 +72,4 @@ jobs:
         run: |
           set -e
           echo "Purging all assets with cache tag using akamai-purge..."
-          akamai purge --edgerc .edgerc --type tag 1fe
+          akamai purge invalidate tag 1fe --edgerc .edgerc 

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -71,5 +71,5 @@ jobs:
       - name: Purge all assets with cache tag
         run: |
           set -e
-          echo "Purging all assets with cache tag using akamai-purge..."
-          akamai purge invalidate tag 1fe --edgerc .edgerc 
+          echo "Purging all assets with cache tag using akamai CLI..."
+          akamai purge invalidate --tag 1fe

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -6,9 +6,6 @@ on:
       - main  # Trigger on push to the main branch
     #paths:
     #  - common-configs/**
-  pull_request:
-    branches:
-      - main  # Trigger on PRs targeting the main branch
 
 jobs:
   upload-and-purge:

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -72,4 +72,4 @@ jobs:
         run: |
           set -e
           echo "Purging all assets with cache tag using akamai-purge..."
-          akamai-purge --edgerc .edgerc cachePurgeByType --tag 1fe
+          akamai purge --edgerc .edgerc cachePurgeByType --tag 1fe

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -47,25 +47,19 @@ jobs:
           sudo apt-get install -y rsync
           rsync --version || { echo "rsync installation failed"; exit 1; }
 
-      - name: Validate rsync password file
+      - name: Sync directories to NetStorage using rsync
         run: |
           set -e
-          if [ ! -f ~/auth ]; then
-            echo "Error: Password file ~/auth is missing."
-            exit 1
-          fi
-          echo "Password file exists and is accessible."
 
-      - name: Validate and set permissions for rsync password file
-        run: |
-          set -e
-          PASSWORD_FILE="$HOME/auth"
-          if [ ! -f "$PASSWORD_FILE" ]; then
-            echo "Error: Password file $PASSWORD_FILE is missing."
-            exit 1
-          fi
-          chmod 600 "$PASSWORD_FILE"
-          echo "Password file permissions set to 600."
+          # Write the SSH key from secrets to a file
+          echo "${{ secrets.AKAMAI_NS_SSH_PRIVATE_KEY }}" > $HOME/key.pem
+          chmod 600 $HOME/key.pem
+
+          # Sync each folder's contents to NetStorage using rsync over SSH
+          for folder in integration development production; do
+            echo "Syncing contents of $folder to NetStorage..."
+            rsync -avv --delete -RO --dry-run -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" "$folder/" "sshacs@1fe.rsync.upload.akamai.com:$folder"
+          done
 
       - name: Upload config files to NetStorage
         run: |
@@ -74,45 +68,8 @@ jobs:
           cp common-configs/demo.json live.json && akamai netstorage upload live.json --directory demo/configs --config ~/auth && rm live.json
           cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json
 
-      - name: Sync directories to NetStorage using rsync
-        run: |
-          set -e
-
-          # Retrieve the rsync password from secrets and write it to the password file
-          akamai_ns_rsync_password=${{ secrets.AKAMAI_NS_RSYNC_PASSWORD }}
-          PASSWORD_FILE="$HOME/auth"
-          echo "$akamai_ns_rsync_password" > "$PASSWORD_FILE"
-          chmod 600 "$PASSWORD_FILE"
-
-          # Define the rsync user
-          RSYNC_USER="1fe"  # Replace with the correct username
-
-          # Sync each folder to NetStorage
-          for folder in integration development production; do
-            echo "Syncing $folder to NetStorage..."
-            timeout 600 rsync -avvv --progress --delete "$folder/" "$RSYNC_USER@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
-          done
-
       - name: Purge all assets with cache tag
         run: |
           set -e
           echo "Purging all assets with cache tag '1fe'..."
           akamai purge invalidate --tag 1fe || echo "Failed to purge assets with cache tag '1fe'"
-
-      - name: Generate list of files to purge
-        run: |
-          set -e
-          for folder in integration development production; do
-            find "$folder" -type f >> files_to_purge.txt
-          done
-          echo "Files to purge:"
-          cat files_to_purge.txt
-
-      - name: Purge individual files from Akamai cache
-        run: |
-          set -e
-          while read file; do
-            url="https://1fe-a.akamaihd.net/$file"
-            echo "Purging $url..."
-            akamai purge invalidate "$url" || echo "Failed to purge $url"
-          done < files_to_purge.txt

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -66,7 +66,7 @@ jobs:
             find "$folder" -type f | while read file; do
               relative_path="${file#$folder/}"  # Get the relative path of the file
               echo "Uploading $file to $folder/$relative_path..."
-              akamai netstorage upload "$file" --directory "$folder/$relative_path" --config ~/auth || echo "Failed to upload $file"
+              akamai netstorage upload "$file" --directory "$folder" --config ~/auth || echo "Failed to upload $file"
             done
           done
 

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -55,7 +55,7 @@ jobs:
           # Sync each folder's contents to NetStorage using rsync over SSH
           for folder in integration development production; do
             echo "Syncing contents of $folder to NetStorage..."
-            rsync -avv --delete -RO --dry-run -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" "$folder/" "sshacs@1fe.rsync.upload.akamai.com:$folder"
+            rsync -avv --delete -RO -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" "$folder/" "sshacs@1fe.rsync.upload.akamai.com:$folder"
           done
 
       - name: Upload config files to NetStorage

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -51,11 +51,15 @@ jobs:
           cp common-configs/demo.json live.json && akamai netstorage upload live.json --directory demo/configs --config ~/auth && rm live.json
           cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json
 
-      - name: Akamai upload help
+      - name: Debug upload paths
         run: |
           set -e
-          akamai netstorage upload --help
-          akamai purge invalidate --help
+          for folder in integration development production; do
+            find "$folder" -type f | while read file; do
+              relative_path="${file#$folder/}"
+              echo "Debug: Uploading $file to $folder/$relative_path"
+            done
+          done
 
       - name: Upload integration, development, and production folders to NetStorage
         run: |
@@ -68,7 +72,7 @@ jobs:
               akamai netstorage upload "$file" --directory "$destination_dir/$relative_path" --config ~/auth || echo "Failed to upload $file"
             done
           done
-          
+
       - name: Purge assets to reset cache
         run: |
           set -e
@@ -76,13 +80,14 @@ jobs:
 
       - name: Generate list of files to purge
         run: |
+          set -e
           for folder in integration development production; do
             find "$folder" -type f >> files_to_purge.txt
           done
           echo "Files to purge:"
           cat files_to_purge.txt
 
-      - name: Purge individual files from Akamai cache
+      - name: Purge uploaded files from Akamai cache
         run: |
           set -e
           while read file; do

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main  # Trigger on PRs targeting the main branch
 
+# trigger 
+
 jobs:
   upload-and-purge:
     runs-on: ubuntu-latest

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -52,7 +52,10 @@ jobs:
       - name: Upload integration, development, and production folders to NetStorage
         run: |
           for folder in integration development production; do
-            akamai netstorage upload "$folder" --directory "$folder" --config ~/auth
+            find "$folder" -type f | while read file; do
+              echo "Uploading $file..."
+              akamai netstorage upload "$file" --directory "$(dirname $file)" --config ~/auth
+            done
           done
           
       - name: Purge assets to reset cache

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -64,12 +64,12 @@ jobs:
           set -e
           for folder in integration development production; do
             find "$folder" -type f | while read file; do
-              relative_path="${file#$folder/}"  # Remove the folder prefix (e.g., 'development/')
-              temp_file="temp_${relative_path##*/}"  # Create a temporary file name
-              echo "Uploading $relative_path to $folder..."
-              cp "$file" "$temp_file" && \
-              akamai netstorage upload "$temp_file" --directory "$folder" --config ~/auth && \
-              rm "$temp_file" || echo "Failed to upload $relative_path"
+              file_name="${file##*/}"  # Extract just the file name
+              destination_dir="${file%/*}"  # Extract the directory path minus the file name
+              echo "Uploading $file_name to $destination_dir..."
+              cp "$file" "$file_name" && \
+              akamai netstorage upload "$file_name" --directory "$destination_dir" --config ~/auth && \
+              rm "$file_name" || echo "Failed to upload $file_name"
             done
           done
 

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -49,6 +49,15 @@ jobs:
           sudo apt-get install -y rsync
           rsync --version || { echo "rsync installation failed"; exit 1; }
 
+      - name: Validate rsync password file
+        run: |
+          set -e
+          if [ ! -f ~/auth ]; then
+            echo "Error: Password file ~/auth is missing."
+            exit 1
+          fi
+          echo "Password file exists and is accessible."
+
       - name: Upload config files to NetStorage
         run: |
           cp common-configs/integration.json live.json && akamai netstorage upload live.json --directory integration/configs --config ~/auth && rm live.json
@@ -61,7 +70,7 @@ jobs:
           set -e
           for folder in integration development production; do
             echo "Syncing $folder to NetStorage..."
-            timeout 300 rsync -av --progress --delete "$folder/" "user@1fe-nsu.akamaihd.net::$folder" --password-file=~/auth || echo "Failed to sync $folder"
+            timeout 120 rsync -avvv --progress --delete "$folder/" "user@1fe-nsu.akamaihd.net::$folder" --password-file=~/auth || echo "Failed to sync $folder"
           done
 
       - name: Purge all assets with cache tag

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -56,7 +56,7 @@ jobs:
           cp common-configs/integration.json live.json && akamai netstorage upload live.json --directory integration/configs --config ~/auth && rm live.json
           cp common-configs/stage.json live.json && akamai netstorage upload live.json --directory stage/configs --config ~/auth && rm live.json
           cp common-configs/demo.json live.json && akamai netstorage upload live.json --directory demo/configs --config ~/auth && rm live.json
-          cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json1
+          cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json
 
       - name: Sync directories to NetStorage using rsync
         run: |

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -10,8 +10,6 @@ on:
     #paths:
     #  - common-configs/**
 
-# test
-
 jobs:
   upload-and-purge:
     runs-on: ubuntu-latest

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -63,9 +63,9 @@ jobs:
           for folder in integration development production; do
             find "$folder" -type f | while read file; do
               relative_path="${file#$folder/}"  # Get the relative path of the file
-              destination_dir="$folder/${relative_path%/*}"  # Use the folder name and relative path's parent directory
-              echo "Uploading $file to $destination_dir..."
-              akamai netstorage upload "$file" --directory "$destination_dir" --config ~/auth || echo "Failed to upload $file"
+              destination_dir="$folder"  # Use only the folder name as the destination directory
+              echo "Uploading $file to $destination_dir/$relative_path..."
+              akamai netstorage upload "$file" --directory "$destination_dir/$relative_path" --config ~/auth || echo "Failed to upload $file"
             done
           done
           

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main  # Trigger on PRs targeting the main branch
+    #paths:
+    #  - common-configs/**
+
+# test
 
 jobs:
   upload-and-purge:
@@ -25,45 +29,20 @@ jobs:
           akamai install netstorage
           akamai install purge
           
+          set -e
           echo "[ccu]
           client_secret = ${{ secrets.AKAMAI_API_CLIENT_SECRET }}
           host = ${{ secrets.AKAMAI_API_CLIENT_HOST }}
           access_token = ${{ secrets.AKAMAI_API_CLIENT_ACCESS_TOKEN }}
           client_token = ${{ secrets.AKAMAI_API_CLIENT_CLIENT_TOKEN }}" > ~/.edgerc
 
+          set -e
           echo "[default]
           key = ${{ secrets.AKAMAI_NS_UPLOAD_ACCOUNT_KEY }}
           id = 1fe
           group = 1FE
           host = 1fe-nsu.akamaihd.net
           cpcode = 1800003" > ~/auth
-
-      - name: Install rsync
-        run: |
-          set -e
-          sudo apt-get update
-          sudo apt-get install -y rsync
-          rsync --version || { echo "rsync installation failed"; exit 1; }
-
-      - name: Validate rsync password file
-        run: |
-          set -e
-          if [ ! -f ~/auth ]; then
-            echo "Error: Password file ~/auth is missing."
-            exit 1
-          fi
-          echo "Password file exists and is accessible."
-
-      - name: Validate and set permissions for rsync password file
-        run: |
-          set -e
-          PASSWORD_FILE="$HOME/auth"
-          if [ ! -f "$PASSWORD_FILE" ]; then
-            echo "Error: Password file $PASSWORD_FILE is missing."
-            exit 1
-          fi
-          chmod 600 "$PASSWORD_FILE"
-          echo "Password file permissions set to 600."
 
       - name: Upload config files to NetStorage
         run: |
@@ -72,25 +51,31 @@ jobs:
           cp common-configs/demo.json live.json && akamai netstorage upload live.json --directory demo/configs --config ~/auth && rm live.json
           cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json
 
-      - name: Sync directories to NetStorage using rsync
+      - name: Akamai upload help
         run: |
           set -e
-          PASSWORD_FILE="$HOME/auth"
-          RSYNC_USER="1fe"  # Replace with the correct username
-          for folder in integration development production; do
-            echo "Syncing $folder to NetStorage..."
-            timeout 600 rsync -avvv --debug=ALL4 --progress --delete "$folder/" "$RSYNC_USER@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
-          done
+          akamai netstorage upload --help
+          akamai purge invalidate --help
 
-      - name: Purge all assets with cache tag
+      - name: Upload integration, development, and production folders to NetStorage
         run: |
           set -e
-          echo "Purging all assets with cache tag '1fe'..."
-          akamai purge invalidate --tag 1fe || echo "Failed to purge assets with cache tag '1fe'"
+          for folder in integration development production; do
+            find "$folder" -type f | while read file; do
+              relative_path="${file#$folder/}"  # Get the relative path of the file
+              destination_dir="$folder"  # Use the folder name as the destination directory
+              echo "Uploading $file to $destination_dir/$relative_path..."
+              akamai netstorage upload "$file" --directory "$destination_dir" --config ~/auth || echo "Failed to upload $file"
+            done
+          done
+          
+      - name: Purge assets to reset cache
+        run: |
+          set -e
+          akamai purge invalidate https://1fe-a.akamaihd.net/integration/configs/live.json https://1fe-a.akamaihd.net/stage/configs/live.json https://1fe-a.akamaihd.net/demo/configs/live.json https://1fe-a.akamaihd.net/production/configs/live.json || echo "Failed to purge config files"
 
       - name: Generate list of files to purge
         run: |
-          set -e
           for folder in integration development production; do
             find "$folder" -type f >> files_to_purge.txt
           done

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -5,7 +5,10 @@ on:
     branches:
       - main  # Trigger on push to the main branch
     #paths:
-      #  - common-configs/**
+    #  - common-configs/**
+  pull_request:
+    branches:
+      - main  # Trigger on PRs targeting the main branch
 
 jobs:
   upload-and-purge:
@@ -68,5 +71,5 @@ jobs:
       - name: Purge all assets with cache tag
         run: |
           set -e
-          echo "Purging all assets with cache tag '1fe'..."
-          akamai purge invalidate --tag 1fe || echo "Failed to purge assets with cache tag '1fe'"
+          echo "Purging all assets with cache tag using akamai-purge..."
+          akamai-purge --edgerc .edgerc cachePurgeByType --tag 1fe

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main  # Trigger on push to the main branch
+  pull_request:
+    branches:
+      - main  # Trigger on PRs targeting the main branch
     #paths:
     #  - common-configs/**
 

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -64,9 +64,12 @@ jobs:
           set -e
           for folder in integration development production; do
             find "$folder" -type f | while read file; do
-              file="${file#$folder/}"  # Remove the folder prefix (e.g., 'development/')
-              echo "Uploading $file to $folder..."
-              akamai netstorage upload "$file" --directory "$folder" --config ~/auth || echo "Failed to upload $file"
+              relative_path="${file#$folder/}"  # Remove the folder prefix (e.g., 'development/')
+              temp_file="temp_${relative_path##*/}"  # Create a temporary file name
+              echo "Uploading $relative_path to $folder..."
+              cp "$file" "$temp_file" && \
+              akamai netstorage upload "$temp_file" --directory "$folder" --config ~/auth && \
+              rm "$temp_file" || echo "Failed to upload $relative_path"
             done
           done
 

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -63,8 +63,8 @@ jobs:
           for folder in integration development production; do
             find "$folder" -type f | while read file; do
               relative_path="${file#$folder/}"  # Get the relative path of the file
-              destination_dir="$folder"  # Use the folder name as the destination directory
-              echo "Uploading $file to $destination_dir/$relative_path..."
+              destination_dir="$folder/${relative_path%/*}"  # Use the folder name and relative path's parent directory
+              echo "Uploading $file to $destination_dir..."
               akamai netstorage upload "$file" --directory "$destination_dir" --config ~/auth || echo "Failed to upload $file"
             done
           done

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -87,8 +87,7 @@ jobs:
           for folder in integration development production; do
             echo "Syncing $folder to NetStorage..."
             
-            # rsync -avv -R -e "ssh -o StrictHostKeyChecking=no -i ${filePath}" ${{ parameters.destination }} sshacs@$RSYNC_DOMAIN:/$UPLOAD_DIRECTORY/${{ parameters.environment }}/
-            timeout 600 rsync -avvv --debug=ALL4 --progress "$folder/" "$RSYNC_USER@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
+          timeout 600 rsync -avvv --debug=ALL4 --progress "$folder/" "$RSYNC_USER@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
           done
 
       - name: Purge all assets with cache tag

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -10,6 +10,8 @@ on:
     #paths:
     #  - common-configs/**
 
+# test
+
 jobs:
   upload-and-purge:
     runs-on: ubuntu-latest

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -37,7 +37,7 @@ jobs:
           key = ${{ secrets.AKAMAI_NS_UPLOAD_ACCOUNT_KEY }}
           id = 1fe
           group = 1FE
-          host = 1fe.rsync.upload.akamai.com
+          host = 1fe-nsu.akamaihd.net
           cpcode = 1800003" > ~/auth
 
       - name: Install rsync

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -65,9 +65,8 @@ jobs:
           for folder in integration development production; do
             find "$folder" -type f | while read file; do
               relative_path="${file#$folder/}"  # Get the relative path of the file
-              destination_dir="$folder"  # Use only the folder name as the destination directory
-              echo "Uploading $file to $destination_dir/$relative_path..."
-              akamai netstorage upload "$file" --directory "$destination_dir" --config ~/auth || echo "Failed to upload $file"
+              echo "Uploading $file to $folder/$relative_path..."
+              akamai netstorage upload "$file" --directory "$folder/$relative_path" --config ~/auth || echo "Failed to upload $file"
             done
           done
 

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -56,6 +56,17 @@ jobs:
           fi
           echo "Password file exists and is accessible."
 
+      - name: Validate and set permissions for rsync password file
+        run: |
+          set -e
+          PASSWORD_FILE="$HOME/auth"
+          if [ ! -f "$PASSWORD_FILE" ]; then
+            echo "Error: Password file $PASSWORD_FILE is missing."
+            exit 1
+          fi
+          chmod 600 "$PASSWORD_FILE"
+          echo "Password file permissions set to 600."
+
       - name: Upload config files to NetStorage
         run: |
           cp common-configs/integration.json live.json && akamai netstorage upload live.json --directory integration/configs --config ~/auth && rm live.json
@@ -67,10 +78,6 @@ jobs:
         run: |
           set -e
           PASSWORD_FILE="$HOME/auth"
-          if [ ! -f "$PASSWORD_FILE" ]; then
-            echo "Error: Password file $PASSWORD_FILE is missing."
-            exit 1
-          fi
           for folder in integration development production; do
             echo "Syncing $folder to NetStorage..."
             timeout 600 rsync -avvv --progress --delete "$folder/" "user@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -51,6 +51,12 @@ jobs:
           cp common-configs/demo.json live.json && akamai netstorage upload live.json --directory demo/configs --config ~/auth && rm live.json
           cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json
 
+      - name: Akamai upload help
+        run: |
+          set -e
+          akamai netstorage upload --help
+          akamai purge invalidate --help
+
       - name: Upload integration, development, and production folders to NetStorage
         run: |
           set -e

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -76,15 +76,17 @@ jobs:
         run: |
           set -e
 
-          akamai_ns_rsync_password = ${{ secrets.AKAMAI_NS_RSYNC_PASSWORD }}
+          akamai_ns_rsync_password=${{ secrets.AKAMAI_NS_RSYNC_PASSWORD }}
           PASSWORD_FILE="$HOME/auth"
           echo "$akamai_ns_rsync_password" > "$PASSWORD_FILE"
           chmod 600 "$PASSWORD_FILE"
-          
+
           RSYNC_USER="1fe"  # Replace with the correct username
           for folder in integration development production; do
             echo "Syncing $folder to NetStorage..."
-            timeout 600 rsync -avvv --debug=ALL4 --progress --delete "$folder/" "$RSYNC_USER@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
+            
+            # rsync -avv -R -e "ssh -o StrictHostKeyChecking=no -i ${filePath}" ${{ parameters.destination }} sshacs@$RSYNC_DOMAIN:/$UPLOAD_DIRECTORY/${{ parameters.environment }}/
+            timeout 600 rsync -avvv --debug=ALL4 --progress "$folder/" "$RSYNC_USER@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
           done
 
       - name: Purge all assets with cache tag

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -29,14 +29,12 @@ jobs:
           akamai install netstorage
           akamai install purge
           
-          set -e
           echo "[ccu]
           client_secret = ${{ secrets.AKAMAI_API_CLIENT_SECRET }}
           host = ${{ secrets.AKAMAI_API_CLIENT_HOST }}
           access_token = ${{ secrets.AKAMAI_API_CLIENT_ACCESS_TOKEN }}
           client_token = ${{ secrets.AKAMAI_API_CLIENT_CLIENT_TOKEN }}" > ~/.edgerc
 
-          set -e
           echo "[default]
           key = ${{ secrets.AKAMAI_NS_UPLOAD_ACCOUNT_KEY }}
           id = 1fe
@@ -63,7 +61,7 @@ jobs:
           set -e
           for folder in integration development production; do
             echo "Syncing $folder to NetStorage..."
-            rsync -av --delete "$folder/" "user@1fe-nsu.akamaihd.net::$folder" --password-file=~/auth || echo "Failed to sync $folder"
+            timeout 300 rsync -av --progress --delete "$folder/" "user@1fe-nsu.akamaihd.net::$folder" --password-file=~/auth || echo "Failed to sync $folder"
           done
 
       - name: Purge all assets with cache tag
@@ -74,6 +72,7 @@ jobs:
 
       - name: Generate list of files to purge
         run: |
+          set -e
           for folder in integration development production; do
             find "$folder" -type f >> files_to_purge.txt
           done

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -64,8 +64,8 @@ jobs:
           set -e
           for folder in integration development production; do
             find "$folder" -type f | while read file; do
-              relative_path="${file#$folder/}"  # Get the relative path of the file
-              echo "Uploading $file to $folder/$relative_path..."
+              file="${file#$folder/}"  # Remove the folder prefix (e.g., 'development/')
+              echo "Uploading $file to $folder..."
               akamai netstorage upload "$file" --directory "$folder" --config ~/auth || echo "Failed to upload $file"
             done
           done

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -4,11 +4,8 @@ on:
   push:
     branches:
       - main  # Trigger on push to the main branch
-  pull_request:
-    branches:
-      - main  # Trigger on PRs targeting the main branch
-
-# trigger 
+    #paths:
+      #  - common-configs/**
 
 jobs:
   upload-and-purge:

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -6,6 +6,9 @@ on:
       - main  # Trigger on push to the main branch
     #paths:
     #  - common-configs/**
+  pull_request:
+    branches:
+      - main  # Trigger on PRs targeting the main branch
 
 jobs:
   upload-and-purge:

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -66,9 +66,14 @@ jobs:
       - name: Sync directories to NetStorage using rsync
         run: |
           set -e
+          PASSWORD_FILE="$HOME/auth"
+          if [ ! -f "$PASSWORD_FILE" ]; then
+            echo "Error: Password file $PASSWORD_FILE is missing."
+            exit 1
+          fi
           for folder in integration development production; do
             echo "Syncing $folder to NetStorage..."
-            timeout 600 rsync -avvv --progress --delete "$folder/" "user@1fe.rsync.upload.akamai.com::$folder" --password-file=~/auth || echo "Failed to sync $folder"
+            timeout 600 rsync -avvv --progress --delete "$folder/" "user@1fe.rsync.upload.akamai.com::$folder" --password-file="$PASSWORD_FILE" || echo "Failed to sync $folder"
           done
 
       - name: Purge all assets with cache tag

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -45,11 +45,17 @@ jobs:
           cp common-configs/stage.json live.json && akamai netstorage upload live.json --directory stage/configs --config ~/auth && rm live.json
           cp common-configs/demo.json live.json && akamai netstorage upload live.json --directory demo/configs --config ~/auth && rm live.json
           cp common-configs/production.json live.json && akamai netstorage upload live.json --directory production/configs --config ~/auth && rm live.json
+
+      - name: Upload integration, development, and production folders to NetStorage
+        run: |
+          for folder in integration development production; do
+            akamai netstorage upload "$folder" --directory "$folder" --config ~/auth
+          done
           
       - name: Purge assets to reset cache
         run: |
           set -e
           akamai purge invalidate https://1fe-a.akamaihd.net/integration/configs/live.json https://1fe-a.akamaihd.net/stage/configs/live.json https://1fe-a.akamaihd.net/demo/configs/live.json https://1fe-a.akamaihd.net/production/configs/live.json
-      
-            
-
+          for folder in integration development production; do
+            akamai purge invalidate "https://1fe-a.akamaihd.net/$folder/*"
+          done

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -65,8 +65,8 @@ jobs:
           for folder in integration development production; do
             find "$folder" -type f | while read file; do
               relative_path="${file#$folder/}"  # Get the relative path of the file
-              destination_dir="$folder/${relative_path%/*}"  # Use the folder name and the parent directory of the file
-              echo "Uploading $file to $destination_dir..."
+              destination_dir="$folder"  # Use only the folder name as the destination directory
+              echo "Uploading $file to $destination_dir/$relative_path..."
               akamai netstorage upload "$file" --directory "$destination_dir" --config ~/auth || echo "Failed to upload $file"
             done
           done


### PR DESCRIPTION
@kevinjc31-docusign 

**Ticket**: https://docusign.atlassian.net/browse/ONEDS-4283

**Description:**
On each merge to [mock-cdn-assets repository,](https://github.com/docusign/mock-cdn-assets) we should mirror the uploaded assets onto akamai cdn (if there has been changes).

Shell assets:

Example:

[mock-cdn-assets/integration/shell/bundle.js at main · docusign/mock-cdn-assets](https://github.com/docusign/mock-cdn-assets/blob/main/integration/shell/bundle.js)  => https://1fe-a.akamaihd.net/integration/1fe-shell/js/bundle.js

Libraries:
Example:

[mock-cdn-assets/integration/libs/lodash/4.17.21/lodash.js at main · docusign/mock-cdn-assets](https://github.com/docusign/mock-cdn-assets/blob/main/integration/libs/lodash/4.17.21/lodash.js)  => https://1fe-a.akamaihd.net/integration/libs/lodash/4.17.21/lodash.js

Widget Assets:
Example:

https://github.com/docusign/mock-cdn-assets/tree/main/integration/widgets/%401fe/starter-kit/1.0.1Connect your Github account  => https://1fe-a.akamaihd.net/integration/widgets/@1fe/starter-kit/1.0.1

**Test plan:** 

[ test pipeline showing rsync doing the mirror upload for development, integration and production](https://github.com/docusign/mock-cdn-assets/actions/runs/15126114607/job/42518374963?pr=8#step:5:52)

**Notes:**
I need to however get the cache tag working. Currently, I'm coming across a permissions issue: 

```
Run set -e
Purging all assets with cache tag using akamai CLI...
Purging...
API Error: 0 unauthorized tag purge account AANA-14XLWY More Info
Purging...... [FAIL]

```
https://github.com/docusign/mock-cdn-assets/actions/runs/15126133512/job/42518426165?pr=8