### PR TITLE
Update CI/CD for Netstorage sync 

### DIFF
--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -8,13 +8,18 @@ on:
     branches:
       - main
     paths:
-      # Only changes made to the files in the specified folders will trigger the push workflow
-      # If FOLDERS_TO_SYNC changes, we need to update these to match
+      # IMPORTANT: If FOLDERS_TO_SYNC (defined in jobs) changes, update these paths to match!
       - 'integration/**' 
       - 'production/**'
   pull_request: 
     branches:
       - main
+
+# Ensures only the latest workflow run for a specific branch or PR proceeds, canceling older runs.
+# This prevents conflicting deployments to 'main' and keeps PR checks efficient for the newest code.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # This job handles the actual deployment and purge for pushes to 'main'
@@ -59,14 +64,12 @@ jobs:
 
       - name: Sync Specified Folders to NetStorage
         env:
+          # IMPORTANT: If these folders change, update the 'on.push.paths' and 'on.pull_request.paths' triggers accordingly!
           FOLDERS_TO_SYNC: "integration production" 
         run: |
-          # This script will attempt to sync all folders and log a warning if rsync has a non-zero exit,
-          # but the step itself will continue and complete.
           echo "Starting sync for folders: $FOLDERS_TO_SYNC to Akamai NetStorage..."
 
           for folder_name in $FOLDERS_TO_SYNC; do
-            # Check if the local source directory exists
             if [ ! -d "$folder_name" ]; then
               echo "WARNING: Local source directory '$folder_name' not found. Skipping sync for this folder."
               continue 
@@ -87,7 +90,18 @@ jobs:
           echo "Purging Akamai cache for tag '1fe'..."
           akamai purge invalidate --tag 1fe
 
-  # This new job provides a dry-run preview for Pull Requests
+      - name: Securely Remove SSH Key
+        if: always() # Ensures this step runs even if previous steps fail
+        run: |
+          echo "Removing SSH private key from runner..."
+          if [ -f "$HOME/key.pem" ]; then
+            shred -u $HOME/key.pem || rm -f $HOME/key.pem # Try shred, fall back to rm for robustness
+            echo "SSH key removed."
+          else
+            echo "SSH key file not found, no removal needed."
+          fi
+
+  # This job provides a dry-run preview for Pull Requests
   pr-sync-dry-run:
     if: github.event_name == 'pull_request' 
     name: PR Sync Dry Run Check
@@ -98,7 +112,7 @@ jobs:
 
       - name: Install rsync and Prepare SSH Key for Dry Run
         run: |
-          set -e # Setup steps should be strict
+          set -e
           echo "Installing rsync..."
           sudo apt-get update -q
           sudo apt-get install -y -q rsync
@@ -111,15 +125,15 @@ jobs:
 
       - name: View Planned Changes with Rsync Dry Run
         env:
+          # IMPORTANT: If these folders change, update the 'on.pull_request.paths' trigger accordingly!
           FOLDERS_TO_SYNC: "integration production" 
         run: |
-          # This script will attempt dry-run for all folders and continue even if rsync reports non-zero exit codes.
           echo "Performing rsync dry run for folders: $FOLDERS_TO_SYNC"
           echo "This will list files that WOULD be synced/deleted if this PR were merged, focusing on content changes."
           echo "No actual changes will be made to the remote server."
           
           for folder_name in $FOLDERS_TO_SYNC; do
-            echo # Blank line for readability
+            echo 
             echo "-----------------------------------------------------"
             echo "  Dry Run for '$folder_name/'..."
             echo "-----------------------------------------------------"
@@ -138,3 +152,14 @@ jobs:
           echo ""
           echo "-----------------------------------------------------"
           echo "rsync dry run attempts complete. Review output above for planned changes."
+
+      - name: Securely Remove SSH Key
+        if: always() # Ensures this step runs even if previous steps fail
+        run: |
+          echo "Removing SSH private key from runner..."
+          if [ -f "$HOME/key.pem" ]; then
+            shred -u $HOME/key.pem || rm -f $HOME/key.pem # Try shred, fall back to rm for robustness
+            echo "SSH key removed."
+          else
+            echo "SSH key file not found, no removal needed."
+          fi

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -10,7 +10,7 @@ on:
       # If FOLDERS_TO_SYNC changes, we need to update these to match
       - 'integration/**' 
       - 'production/**'
-  pull_request:
+  pull_request: 
     branches:
       - main  
 
@@ -22,35 +22,43 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Tools and Prepare Credentials
+      - name: Install Akamai CLI and Purge Module
         run: |
           set -e
-          
-          # Akamai CLI and Purge Module
           echo "Installing Akamai CLI and Purge module..."
           curl -sL https://github.com/akamai/cli/releases/download/v2.0.0/akamai-v2.0.0-linuxamd64 -o akamai
           chmod +x akamai
           sudo mv akamai /usr/local/bin/
-          akamai install purge # Only installing purge module
-          
-          # Akamai API Credentials for Purge (needed for .edgerc)
+          akamai install purge 
+          echo "Akamai CLI and Purge module installed."
+
+      - name: Create Akamai .edgerc File for Purge
+        run: |
+          set -e
           echo "Creating .edgerc for Akamai API access..."
           echo "[ccu]
           client_secret = ${{ secrets.AKAMAI_API_CLIENT_SECRET }}
           host = ${{ secrets.AKAMAI_API_CLIENT_HOST }}
           access_token = ${{ secrets.AKAMAI_API_CLIENT_ACCESS_TOKEN }}
           client_token = ${{ secrets.AKAMAI_API_CLIENT_CLIENT_TOKEN }}" > ~/.edgerc
+          echo ".edgerc file created."
 
-          # Install rsync
+      - name: Install rsync for directory syncing
+        run: |
+          set -e
           echo "Installing rsync..."
           sudo apt-get update -q
           sudo apt-get install -y -q rsync
+          rsync --version # Verify installation
+          echo "rsync installed."
           
-          # Prepare SSH key for rsync
+      - name: Prepare SSH Key for rsync
+        run: |
+          set -e
           echo "Setting up SSH key for rsync..."
           echo "${{ secrets.AKAMAI_NS_SSH_PRIVATE_KEY }}" > $HOME/key.pem
           chmod 600 $HOME/key.pem
-          echo "Tool setup and credential preparation complete."
+          echo "SSH key for rsync is ready."
 
       - name: Sync Specified Folders to NetStorage
         env:

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -58,7 +58,7 @@ jobs:
           # Sync each folder's contents to NetStorage using rsync over SSH
           for folder in integration production; do
             echo "Syncing contents of $folder to NetStorage..."
-            rsync -avv --delete -RO -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" "$folder/" "sshacs@1fe.rsync.upload.akamai.com:$folder"
+            rsync -avv --delete -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" "$folder/" "sshacs@1fe.rsync.upload.akamai.com:$folder/"
           done
 
       - name: Purge all assets with cache tag

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           # This script will attempt dry-run for all folders and continue even if rsync reports non-zero exit codes.
           echo "Performing rsync dry run for folders: $FOLDERS_TO_SYNC"
-          echo "This will list files that WOULD be synced/deleted if this PR were merged."
+          echo "This will list files that WOULD be synced/deleted if this PR were merged, focusing on content changes."
           echo "No actual changes will be made to the remote server."
           
           for folder_name in $FOLDERS_TO_SYNC; do
@@ -132,12 +132,11 @@ jobs:
               continue 
             fi
             
-            # Using -avv for verbose rsync output, consistent with the deploy job
-            rsync -avv --dry-run --delete \
+            rsync -avvc --dry-run --delete \
               -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
               "$folder_name/" \
               "sshacs@1fe.rsync.upload.akamai.com:$folder_name/" \
-            || echo "    NOTE: rsync dry run for '$folder_name' finished with a non-zero exit code ($?). This is often normal for dry runs showing changes or simulating metadata issues. Review rsync output above for details of what would change."
+            || echo "    NOTE: rsync dry run for '$folder_name' finished with a non-zero exit code ($?). This can be normal for dry runs showing potential changes (especially with --delete) or if it simulates metadata issues. Review rsync output above for details of what would change."
           done
           echo ""
           echo "-----------------------------------------------------"

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -56,10 +56,11 @@ jobs:
         env:
           FOLDERS_TO_SYNC: "integration production" 
         run: |
+          # This script will attempt to sync all folders and continue even if rsync reports errors.
           echo "Starting sync for folders: $FOLDERS_TO_SYNC to Akamai NetStorage..."
 
           for folder_name in $FOLDERS_TO_SYNC; do
-            # Check if the local source directory exists to prevent rsync errors
+            # Check if the local source directory exists
             if [ ! -d "$folder_name" ]; then
               echo "WARNING: Local source directory '$folder_name' not found. Skipping sync for this folder."
               continue 
@@ -69,9 +70,11 @@ jobs:
             rsync -avv --delete \
               -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
               "$folder_name/" \
-              "sshacs@1fe.rsync.upload.akamai.com:$folder_name/"
+              "sshacs@1fe.rsync.upload.akamai.com:$folder_name/" \
+            || echo "WARNING: rsync for '$folder_name' finished with a non-zero exit code ($?). The workflow continued, but please check rsync logs above for any errors (e.g., 'failed to set times', or more critical issues)."
+            # The '|| echo ...' ensures that even if rsync fails (non-zero exit), 
           done
-          echo "Sync to NetStorage complete for specified folders."
+          echo "Sync to NetStorage attempts complete for all specified folders. Review logs for any rsync warnings or errors."
 
       - name: Purge Akamai Cache by Cache Tag
         run: |

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -1,4 +1,6 @@
-# The goal of this GitHub Actions workflow is to sync specific folders (FOLDERS_TO_SYNC) to Akamai NetStorage 1FE and purge the Akamai cache.
+# The goal of this GitHub Actions workflow is:
+# 1. To sync specific folders (FOLDERS_TO_SYNC) to Akamai NetStorage 1FE and purge the Akamai cache for pushes to the main branch.
+# 2. To provide a dry-run preview for Pull Requests.
 name: Sync Folders to 1FE Netstorage and Purge Akamai Cache
 
 on:
@@ -6,62 +8,64 @@ on:
     branches:
       - main
     paths:
-      # Only changes made to the files in the specified folders will trigger this workflow
+      # Only changes made to the files in the specified folders will trigger the push workflow
       # If FOLDERS_TO_SYNC changes, we need to update these to match
       - 'integration/**' 
       - 'production/**'
+  pull_request: 
+    branches:
+      - main
+    # paths:
+    #   - 'integration/**'
+    #   - 'production/**'
 
 jobs:
+  # This job handles the actual deployment and purge for pushes to 'main'
   upload-and-purge:
+    if: github.event_name == 'push'
+    name: Upload to NetStorage and Purge Cache =
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Akamai CLI and Purge Module
+      - name: Install Akamai CLI, Akamai Purge, Rsync, and Prepare Credentials
         run: |
           set -e
+          
+          # Akamai CLI and Purge Module
           echo "Installing Akamai CLI and Purge module..."
           curl -sL https://github.com/akamai/cli/releases/download/v2.0.0/akamai-v2.0.0-linuxamd64 -o akamai
           chmod +x akamai
           sudo mv akamai /usr/local/bin/
           akamai install purge 
-          echo "Akamai CLI and Purge module installed."
-
-      - name: Create Akamai .edgerc File for Purge
-        run: |
-          set -e
+          
+          # Akamai API Credentials for Purge (needed for .edgerc)
           echo "Creating .edgerc for Akamai API access..."
           echo "[ccu]
           client_secret = ${{ secrets.AKAMAI_API_CLIENT_SECRET }}
           host = ${{ secrets.AKAMAI_API_CLIENT_HOST }}
           access_token = ${{ secrets.AKAMAI_API_CLIENT_ACCESS_TOKEN }}
           client_token = ${{ secrets.AKAMAI_API_CLIENT_CLIENT_TOKEN }}" > ~/.edgerc
-          echo ".edgerc file created."
 
-      - name: Install rsync for directory syncing
-        run: |
-          set -e
+          # Install rsync
           echo "Installing rsync..."
           sudo apt-get update -q
           sudo apt-get install -y -q rsync
-          rsync --version # Verify installation
-          echo "rsync installed."
+          rsync --version 
           
-      - name: Prepare SSH Key for rsync
-        run: |
-          set -e
+          # Prepare SSH key for rsync
           echo "Setting up SSH key for rsync..."
           echo "${{ secrets.AKAMAI_NS_SSH_PRIVATE_KEY }}" > $HOME/key.pem
           chmod 600 $HOME/key.pem
-          echo "SSH key for rsync is ready."
+          echo "Tool setup and credential preparation complete."
 
       - name: Sync Specified Folders to NetStorage
         env:
           FOLDERS_TO_SYNC: "integration production" 
         run: |
-          # This script will attempt to sync all folders and continue even if rsync reports errors.
+          # This script will attempt to sync all folders and log a warning if rsync has a non-zero exit,
+          # but the step itself will continue and complete.
           echo "Starting sync for folders: $FOLDERS_TO_SYNC to Akamai NetStorage..."
 
           for folder_name in $FOLDERS_TO_SYNC; do
@@ -77,7 +81,6 @@ jobs:
               "$folder_name/" \
               "sshacs@1fe.rsync.upload.akamai.com:$folder_name/" \
             || echo "WARNING: rsync for '$folder_name' finished with a non-zero exit code ($?). The workflow continued, but please check rsync logs above for any errors (e.g., 'failed to set times', or more critical issues)."
-            # The '|| echo ...' ensures that even if rsync fails (non-zero exit), 
           done
           echo "Sync to NetStorage attempts complete for all specified folders. Review logs for any rsync warnings or errors."
 
@@ -86,3 +89,56 @@ jobs:
           set -e
           echo "Purging Akamai cache for tag '1fe'..."
           akamai purge invalidate --tag 1fe
+
+  # This new job provides a dry-run preview for Pull Requests
+  pr-sync-dry-run:
+    if: github.event_name == 'pull_request' 
+    name: PR Sync Dry Run Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install rsync and Prepare SSH Key for Dry Run
+        run: |
+          set -e # Setup steps should be strict
+          echo "Installing rsync..."
+          sudo apt-get update -q
+          sudo apt-get install -y -q rsync
+          rsync --version
+          
+          echo "Setting up SSH key for rsync dry-run..."
+          echo "${{ secrets.AKAMAI_NS_SSH_PRIVATE_KEY }}" > $HOME/key.pem
+          chmod 600 $HOME/key.pem
+          echo "SSH key for rsync dry-run is ready."
+
+      - name: View Planned Changes with Rsync Dry Run
+        env:
+          FOLDERS_TO_SYNC: "integration production" 
+        run: |
+          # This script will attempt dry-run for all folders and continue even if rsync reports non-zero exit codes.
+          echo "Performing rsync dry run for folders: $FOLDERS_TO_SYNC"
+          echo "This will list files that WOULD be synced/deleted if this PR were merged."
+          echo "No actual changes will be made to the remote server."
+          
+          for folder_name in $FOLDERS_TO_SYNC; do
+            echo # Blank line for readability
+            echo "-----------------------------------------------------"
+            echo "  Dry Run for '$folder_name/'..."
+            echo "-----------------------------------------------------"
+            
+            if [ ! -d "$folder_name" ]; then
+              echo "    WARNING: Local source directory '$folder_name' not found. Skipping dry run for this folder."
+              continue 
+            fi
+            
+            # Using -avv for verbose rsync output, consistent with the deploy job
+            rsync -avv --dry-run --delete \
+              -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
+              "$folder_name/" \
+              "sshacs@1fe.rsync.upload.akamai.com:$folder_name/" \
+            || echo "    NOTE: rsync dry run for '$folder_name' finished with a non-zero exit code ($?). This is often normal for dry runs showing changes or simulating metadata issues. Review rsync output above for details of what would change."
+          done
+          echo ""
+          echo "-----------------------------------------------------"
+          echo "rsync dry run attempts complete. Review output above for planned changes."

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -20,7 +20,7 @@ jobs:
   # This job handles the actual deployment and purge for pushes to 'main'
   upload-and-purge:
     if: github.event_name == 'push'
-    name: Upload to NetStorage and Purge Cache =
+    name: Upload to NetStorage and Purge Cache
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -47,19 +47,67 @@ jobs:
           sudo apt-get install -y rsync
           rsync --version || { echo "rsync installation failed"; exit 1; }
 
-      - name: Sync directories to NetStorage using rsync
+      - name: Sync directories and clean up development/demo from NetStorage
         run: |
-          set -e
+          set -e # Exit immediately if a command exits with a non-zero status
 
-          # Write the SSH key from secrets to a file
+          # Ensure SSH key is available (as in your original script)
           echo "${{ secrets.AKAMAI_NS_SSH_PRIVATE_KEY }}" > $HOME/key.pem
           chmod 600 $HOME/key.pem
 
-          # Sync each folder's contents to NetStorage using rsync over SSH
-          for folder in integration production; do
-            echo "Syncing contents of $folder to NetStorage..."
-            rsync -avv --delete -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" "$folder/" "sshacs@1fe.rsync.upload.akamai.com:$folder/"
+          # Define folders for cleanup (these will be emptied on remote)
+          cleanup_folders_on_remote="development demo"
+
+          # Create empty local versions of these directories on the GitHub Runner
+          echo "Creating temporary empty local directories for cleanup: $cleanup_folders_on_remote"
+          for folder_to_cleanup in $cleanup_folders_on_remote; do
+            mkdir "$folder_to_cleanup"
+            echo "Created empty local directory: $folder_to_cleanup"
           done
+
+          # Define all folders to be processed by rsync:
+          # - Your standard sync folders (integration, production)
+          # - The folders marked for cleanup (development, demo)
+          # For cleanup folders, rsync will use the empty local versions created above.
+          all_folders_to_process="integration production $cleanup_folders_on_remote"
+          
+          echo "Starting rsync process for folders: $all_folders_to_process"
+          for folder in $all_folders_to_process; do
+            echo "-----------------------------------------------------"
+            echo "Processing folder: $folder"
+            
+            is_cleanup_target=false
+            for cf_item in $cleanup_folders_on_remote; do
+              if [ "$folder" == "$cf_item" ]; then
+                is_cleanup_target=true
+                break
+              fi
+            done
+
+            if [ "$is_cleanup_target" = true ]; then
+              echo "--> ACTION: This is '$folder'. Its contents on remote will be deleted to match the empty local source."
+            else
+              echo "--> ACTION: This is '$folder'. It will be synced from local source to remote."
+            fi
+            
+            rsync -avv --delete \
+              -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
+              "$folder/" \
+              "sshacs@1fe.rsync.upload.akamai.com:$folder/"
+            echo "Finished rsync for folder: $folder"
+          done
+          echo "-----------------------------------------------------"
+
+          echo "Attempting to remove the emptied remote directories: $cleanup_folders_on_remote"
+          for folder_to_cleanup in $cleanup_folders_on_remote; do
+            echo "Attempting rmdir for remote '$folder_to_cleanup' directory..."
+            ssh -o StrictHostKeyChecking=no -i $HOME/key.pem \
+              sshacs@1fe.rsync.upload.akamai.com \
+              "rmdir $folder_to_cleanup" \
+              && echo "--> SUCCESS: Successfully removed remote directory '$folder_to_cleanup'." \
+              || echo "--> INFO: Could not remove remote directory '$folder_to_cleanup'. It might not have existed, not been empty, or an issue occurred (this may be okay if rsync already handled it or it was previously removed)."
+          done
+          echo "-----------------------------------------------------"
 
       - name: Purge all assets with cache tag
         run: |

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -18,9 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Akamai CLI, NetStorage Module, and rsync
+      - name: Install Akamai CLI, NetStorage Module, rsync, and Prepare Credentials
         run: |
-          set -e
+          set -e # This setup part should be strict
+          echo "Installing Akamai CLI, modules, and rsync..."
           # Akamai CLI and Modules
           curl -sL https://github.com/akamai/cli/releases/download/v2.0.0/akamai-v2.0.0-linuxamd64 -o akamai
           chmod +x akamai
@@ -28,15 +29,14 @@ jobs:
           akamai install netstorage
           akamai install purge
           
-          # Akamai API Credentials
+          # Akamai API Credentials for Purge
           echo "[ccu]
           client_secret = ${{ secrets.AKAMAI_API_CLIENT_SECRET }}
           host = ${{ secrets.AKAMAI_API_CLIENT_HOST }}
           access_token = ${{ secrets.AKAMAI_API_CLIENT_ACCESS_TOKEN }}
           client_token = ${{ secrets.AKAMAI_API_CLIENT_CLIENT_TOKEN }}" > ~/.edgerc
 
-          # NetStorage Upload Credentials (for rsync via SSH key, and also for NetStorage CLI if used)
-          # The rsync part primarily uses the SSH key. This auth file is for the 'akamai netstorage' CLI commands.
+          # NetStorage Upload Account Credentials (for Akamai NetStorage CLI commands, rsync uses SSH key)
           echo "[default]
           key = ${{ secrets.AKAMAI_NS_UPLOAD_ACCOUNT_KEY }}
           id = 1fe 
@@ -47,57 +47,59 @@ jobs:
           # Install rsync
           sudo apt-get update
           sudo apt-get install -y rsync
-          rsync --version || { echo "rsync installation failed"; exit 1; }
+          rsync --version || { echo "FATAL: rsync installation failed"; exit 1; }
           
-          # Prepare SSH key for rsync
           echo "Setting up SSH key for rsync..."
           echo "${{ secrets.AKAMAI_NS_SSH_PRIVATE_KEY }}" > $HOME/key.pem
           chmod 600 $HOME/key.pem
+          echo "Setup complete."
 
+      # --- ONE-TIME CLEANUP STEP ---
+      # This step should be removed or commented out after successful execution.
       - name: Perform One-Time Cleanup of Remote 'development' and 'demo' Directories
+        # This step will attempt all cleanup actions and report on them.
+        # `set +e` ensures the script continues even if some rsync/ssh commands fail for one target.
         run: |
-          # Not using 'set -e' here to ensure all cleanup attempts for all targets are made.
+          set +e # Allow commands to fail without stopping the whole script block
           echo "=== Starting One-Time Remote Directory Cleanup ==="
           
           cleanup_targets="development demo"
-          critical_cleanup_error_occurred=false
+          overall_cleanup_step_status=0 # 0 for success, 1 for critical failure
 
           echo "Creating local empty directories for cleanup: $cleanup_targets"
           for target_dir in $cleanup_targets; do
             if ! mkdir -p "$target_dir"; then
-              echo "    ERROR: Failed to create local directory '$target_dir'."
-              critical_cleanup_error_occurred=true # Consider this critical enough
+              echo "    ERROR: Failed to create local directory '$target_dir'. This is a critical local error."
+              overall_cleanup_step_status=1 # Mark critical failure
             fi
           done
 
-          if [ "$critical_cleanup_error_occurred" = true ]; then
+          if [ "$overall_cleanup_step_status" -ne 0 ]; then
             echo "Halting cleanup step due to errors creating essential local directories."
-            exit 1 # Fail this step if we can't even prepare locally
+            exit "$overall_cleanup_step_status"
           fi
 
           echo "Attempting to empty contents of remote directories: $cleanup_targets"
           for target_dir in $cleanup_targets; do
+            echo "  ---------------------------------------------------"
             echo "  Processing cleanup for remote '$target_dir'..."
-            # Using -av instead of -avv to slightly reduce log verbosity for this step
-            rsync -av --delete \
+            # Using -avv for detailed logs, consistent with other steps
+            rsync -avv --delete \
               -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
               "$target_dir/" \
               "sshacs@1fe.rsync.upload.akamai.com:$target_dir/"
             rsync_exit_code=$?
             if [ $rsync_exit_code -eq 0 ]; then
-              echo "    Successfully emptied remote '$target_dir' (or it was already empty/non-existent)."
+              echo "    SUCCESS: rsync successfully emptied remote '$target_dir' (or it was already empty/non-existent)."
+            elif [ $rsync_exit_code -eq 23 ] || [ $rsync_exit_code -eq 24 ]; then
+              echo "    WARNING: rsync for '$target_dir' (to empty contents) finished with code $rsync_exit_code. This often means the directory was emptied but metadata updates on deleted items failed (common) or source files vanished (less common for empty source). The directory might be usable for rmdir."
             else
-              # Exit code 23 can occur if setting times on deleted subdirs fails, but dir might still be empty.
-              # For cleanup, we'll note this as a warning but not necessarily a critical failure for this step's overall status,
-              # as the main goal is to empty content, and rmdir will be attempted next.
-              echo "    WARNING: rsync for '$target_dir' (to empty contents) finished with code $rsync_exit_code. The directory might be empty, but review logs if issues persist."
-              if [ $rsync_exit_code -ne 23 ] && [ $rsync_exit_code -ne 24 ]; then # 24 is "vanished source files"
-                 # If it's an error other than the common ones seen with deletions, mark it.
-                 critical_cleanup_error_occurred=true
-              fi
+              echo "    ERROR: rsync for '$target_dir' failed with critical exit code $rsync_exit_code. Contents may not be empty."
+              overall_cleanup_step_status=1 # Mark critical failure
             fi
           done
 
+          echo "  ---------------------------------------------------"
           echo "Attempting to remove the (now hopefully empty) remote directories: $cleanup_targets"
           for target_dir in $cleanup_targets; do
             echo "  Attempting rmdir for remote '$target_dir'..."
@@ -106,22 +108,24 @@ jobs:
               "rmdir $target_dir"
             ssh_exit_code=$?
             if [ $ssh_exit_code -eq 0 ]; then
-              echo "    Successfully removed remote directory '$target_dir'."
+              echo "    SUCCESS: Successfully removed remote directory '$target_dir'."
             else
-              echo "    INFO: Could not remove remote directory '$target_dir' (exit code $ssh_exit_code). Common reasons: it didn't exist, wasn't fully emptied, or a permission issue."
-              # Not marking this as a critical_cleanup_error, as emptying was the primary goal.
+              echo "    INFO: Could not remove remote directory '$target_dir' (ssh exit code $ssh_exit_code). Common reasons: it didn't exist, wasn't fully emptied by rsync, or a permission issue."
+              # Not necessarily a critical failure for this cleanup step's overall status,
+              # as emptying contents was the primary rsync goal.
             fi
           done
 
+          echo "  ---------------------------------------------------"
           echo "=== One-Time Remote Directory Cleanup Attempted ==="
           echo "IMPORTANT: Review the logs from this step carefully."
           echo "           For all future workflow runs, this 'Perform One-Time Cleanup...' step"
           echo "           should be REMOVED or COMMENTED OUT from your YAML file."
           
-          if [ "$critical_cleanup_error_occurred" = true ]; then
-            echo "ERROR: Some critical rsync operations during cleanup failed. Please review logs."
-            exit 1 # Fail this step if rsync had critical errors
+          if [ "$overall_cleanup_step_status" -ne 0 ]; then
+            echo "ERROR: Critical errors occurred during the rsync phase of cleanup. Please review logs."
           fi
+          exit "$overall_cleanup_step_status" # Ensure step status reflects critical rsync errors
 
       - name: Sync Standard Directories (integration, production) to NetStorage
         run: |
@@ -132,16 +136,17 @@ jobs:
 
           echo "Processing standard sync for folders: $standard_sync_folders"
           for folder_name in $standard_sync_folders; do
+            echo "  ---------------------------------------------------"
             echo "  Processing '$folder_name'..."
-            # Using -avv for main sync to get detailed logs as before
             rsync -avv --delete \
               -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
               "$folder_name/" \
               "sshacs@1fe.rsync.upload.akamai.com:$folder_name/"
             echo "  Finished rsync for '$folder_name'."
           done
+          echo "  ---------------------------------------------------"
           echo "=== Standard Directory Sync Reported Completion by rsync ==="
-          echo "Note: If rsync reported errors (e.g., exit code 23 for failed 'set times'), this step may still be marked as failed by GitHub Actions due to 'set -e'."
+          echo "Note: If rsync reported errors (e.g., exit code 23 for 'failed to set times'), this step may still be marked as failed by GitHub Actions due to 'set -e'."
 
       - name: Purge all assets with cache tag
         run: |

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -15,9 +15,6 @@ on:
   pull_request: 
     branches:
       - main
-    # paths:
-    #   - 'integration/**'
-    #   - 'production/**'
 
 jobs:
   # This job handles the actual deployment and purge for pushes to 'main'

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -1,15 +1,3 @@
-name: Upload Config Files and Purge Akamai Cache
-
-on:
-  push:
-    branches:
-      - main  # Trigger on push to the main branch
-    #paths:
-    #  - common-configs/**
-  pull_request:
-    branches:
-      - main  # Trigger on PRs targeting the main branch
-
 jobs:
   upload-and-purge:
     runs-on: ubuntu-latest
@@ -18,96 +6,130 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Akamai CLI and NetStorage Module
+      - name: Install Akamai CLI, NetStorage Module, and rsync
         run: |
           set -e
+          # Akamai CLI and Modules
           curl -sL https://github.com/akamai/cli/releases/download/v2.0.0/akamai-v2.0.0-linuxamd64 -o akamai
           chmod +x akamai
           sudo mv akamai /usr/local/bin/
           akamai install netstorage
           akamai install purge
           
+          # Akamai API Credentials
           echo "[ccu]
           client_secret = ${{ secrets.AKAMAI_API_CLIENT_SECRET }}
           host = ${{ secrets.AKAMAI_API_CLIENT_HOST }}
           access_token = ${{ secrets.AKAMAI_API_CLIENT_ACCESS_TOKEN }}
           client_token = ${{ secrets.AKAMAI_API_CLIENT_CLIENT_TOKEN }}" > ~/.edgerc
 
+          # NetStorage Upload Credentials (for rsync via SSH key, and also for NetStorage CLI if used)
+          # The rsync part primarily uses the SSH key. This auth file is for the 'akamai netstorage' CLI commands.
           echo "[default]
           key = ${{ secrets.AKAMAI_NS_UPLOAD_ACCOUNT_KEY }}
-          id = 1fe
+          id = 1fe 
           group = 1FE
           host = 1fe-nsu.akamaihd.net
           cpcode = 1800003" > ~/auth
 
-      - name: Install rsync
-        run: |
-          set -e
+          # Install rsync
           sudo apt-get update
           sudo apt-get install -y rsync
           rsync --version || { echo "rsync installation failed"; exit 1; }
-
-      - name: Sync directories and clean up development/demo from NetStorage
-        run: |
-          set -e # Exit immediately if a command exits with a non-zero status
-
-          # Ensure SSH key is available (as in your original script)
+          
+          # Prepare SSH key for rsync
+          echo "Setting up SSH key for rsync..."
           echo "${{ secrets.AKAMAI_NS_SSH_PRIVATE_KEY }}" > $HOME/key.pem
           chmod 600 $HOME/key.pem
 
-          # Define folders for cleanup (these will be emptied on remote)
-          cleanup_folders_on_remote="development demo"
-
-          # Create empty local versions of these directories on the GitHub Runner
-          echo "Creating temporary empty local directories for cleanup: $cleanup_folders_on_remote"
-          for folder_to_cleanup in $cleanup_folders_on_remote; do
-            mkdir "$folder_to_cleanup"
-            echo "Created empty local directory: $folder_to_cleanup"
-          done
-
-          # Define all folders to be processed by rsync:
-          # - Your standard sync folders (integration, production)
-          # - The folders marked for cleanup (development, demo)
-          # For cleanup folders, rsync will use the empty local versions created above.
-          all_folders_to_process="integration production $cleanup_folders_on_remote"
+      - name: Perform One-Time Cleanup of Remote 'development' and 'demo' Directories
+        run: |
+          # Not using 'set -e' here to ensure all cleanup attempts for all targets are made.
+          echo "=== Starting One-Time Remote Directory Cleanup ==="
           
-          echo "Starting rsync process for folders: $all_folders_to_process"
-          for folder in $all_folders_to_process; do
-            echo "-----------------------------------------------------"
-            echo "Processing folder: $folder"
-            
-            is_cleanup_target=false
-            for cf_item in $cleanup_folders_on_remote; do
-              if [ "$folder" == "$cf_item" ]; then
-                is_cleanup_target=true
-                break
-              fi
-            done
+          cleanup_targets="development demo"
+          critical_cleanup_error_occurred=false
 
-            if [ "$is_cleanup_target" = true ]; then
-              echo "--> ACTION: This is '$folder'. Its contents on remote will be deleted to match the empty local source."
-            else
-              echo "--> ACTION: This is '$folder'. It will be synced from local source to remote."
+          echo "Creating local empty directories for cleanup: $cleanup_targets"
+          for target_dir in $cleanup_targets; do
+            if ! mkdir -p "$target_dir"; then
+              echo "    ERROR: Failed to create local directory '$target_dir'."
+              critical_cleanup_error_occurred=true # Consider this critical enough
             fi
-            
-            rsync -avv --delete \
-              -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
-              "$folder/" \
-              "sshacs@1fe.rsync.upload.akamai.com:$folder/"
-            echo "Finished rsync for folder: $folder"
           done
-          echo "-----------------------------------------------------"
 
-          echo "Attempting to remove the emptied remote directories: $cleanup_folders_on_remote"
-          for folder_to_cleanup in $cleanup_folders_on_remote; do
-            echo "Attempting rmdir for remote '$folder_to_cleanup' directory..."
+          if [ "$critical_cleanup_error_occurred" = true ]; then
+            echo "Halting cleanup step due to errors creating essential local directories."
+            exit 1 # Fail this step if we can't even prepare locally
+          fi
+
+          echo "Attempting to empty contents of remote directories: $cleanup_targets"
+          for target_dir in $cleanup_targets; do
+            echo "  Processing cleanup for remote '$target_dir'..."
+            # Using -av instead of -avv to slightly reduce log verbosity for this step
+            rsync -av --delete \
+              -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
+              "$target_dir/" \
+              "sshacs@1fe.rsync.upload.akamai.com:$target_dir/"
+            rsync_exit_code=$?
+            if [ $rsync_exit_code -eq 0 ]; then
+              echo "    Successfully emptied remote '$target_dir' (or it was already empty/non-existent)."
+            else
+              # Exit code 23 can occur if setting times on deleted subdirs fails, but dir might still be empty.
+              # For cleanup, we'll note this as a warning but not necessarily a critical failure for this step's overall status,
+              # as the main goal is to empty content, and rmdir will be attempted next.
+              echo "    WARNING: rsync for '$target_dir' (to empty contents) finished with code $rsync_exit_code. The directory might be empty, but review logs if issues persist."
+              if [ $rsync_exit_code -ne 23 ] && [ $rsync_exit_code -ne 24 ]; then # 24 is "vanished source files"
+                 # If it's an error other than the common ones seen with deletions, mark it.
+                 critical_cleanup_error_occurred=true
+              fi
+            fi
+          done
+
+          echo "Attempting to remove the (now hopefully empty) remote directories: $cleanup_targets"
+          for target_dir in $cleanup_targets; do
+            echo "  Attempting rmdir for remote '$target_dir'..."
             ssh -o StrictHostKeyChecking=no -i $HOME/key.pem \
               sshacs@1fe.rsync.upload.akamai.com \
-              "rmdir $folder_to_cleanup" \
-              && echo "--> SUCCESS: Successfully removed remote directory '$folder_to_cleanup'." \
-              || echo "--> INFO: Could not remove remote directory '$folder_to_cleanup'. It might not have existed, not been empty, or an issue occurred (this may be okay if rsync already handled it or it was previously removed)."
+              "rmdir $target_dir"
+            ssh_exit_code=$?
+            if [ $ssh_exit_code -eq 0 ]; then
+              echo "    Successfully removed remote directory '$target_dir'."
+            else
+              echo "    INFO: Could not remove remote directory '$target_dir' (exit code $ssh_exit_code). Common reasons: it didn't exist, wasn't fully emptied, or a permission issue."
+              # Not marking this as a critical_cleanup_error, as emptying was the primary goal.
+            fi
           done
-          echo "-----------------------------------------------------"
+
+          echo "=== One-Time Remote Directory Cleanup Attempted ==="
+          echo "IMPORTANT: Review the logs from this step carefully."
+          echo "           For all future workflow runs, this 'Perform One-Time Cleanup...' step"
+          echo "           should be REMOVED or COMMENTED OUT from your YAML file."
+          
+          if [ "$critical_cleanup_error_occurred" = true ]; then
+            echo "ERROR: Some critical rsync operations during cleanup failed. Please review logs."
+            exit 1 # Fail this step if rsync had critical errors
+          fi
+
+      - name: Sync Standard Directories (integration, production) to NetStorage
+        run: |
+          set -e # Exit immediately if any command here fails (recommended for main sync)
+
+          echo "=== Starting Standard Directory Sync ==="
+          standard_sync_folders="integration production"
+
+          echo "Processing standard sync for folders: $standard_sync_folders"
+          for folder_name in $standard_sync_folders; do
+            echo "  Processing '$folder_name'..."
+            # Using -avv for main sync to get detailed logs as before
+            rsync -avv --delete \
+              -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
+              "$folder_name/" \
+              "sshacs@1fe.rsync.upload.akamai.com:$folder_name/"
+            echo "  Finished rsync for '$folder_name'."
+          done
+          echo "=== Standard Directory Sync Reported Completion by rsync ==="
+          echo "Note: If rsync reported errors (e.g., exit code 23 for failed 'set times'), this step may still be marked as failed by GitHub Actions due to 'set -e'."
 
       - name: Purge all assets with cache tag
         run: |

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -10,9 +10,6 @@ on:
       # If FOLDERS_TO_SYNC changes, we need to update these to match
       - 'integration/**' 
       - 'production/**'
-  pull_request: 
-    branches:
-      - main  
 
 jobs:
   upload-and-purge:

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -1,3 +1,15 @@
+name: Upload Config Files and Purge Akamai Cache
+
+on:
+  push:
+    branches:
+      - main  # Trigger on push to the main branch
+    #paths:
+    #  - common-configs/**
+  pull_request:
+    branches:
+      - main  # Trigger on PRs targeting the main branch
+
 jobs:
   upload-and-purge:
     runs-on: ubuntu-latest

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -63,7 +63,7 @@ jobs:
           set +e # Allow commands to fail without stopping the whole script block
           echo "=== Starting One-Time Remote Directory Cleanup ==="
           
-          cleanup_targets="development demo"
+          cleanup_targets="development demo stage"
           overall_cleanup_step_status=0 # 0 for success, 1 for critical failure
 
           echo "Creating local empty directories for cleanup: $cleanup_targets"

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -56,7 +56,6 @@ jobs:
         env:
           FOLDERS_TO_SYNC: "integration production" 
         run: |
-          set -e
           echo "Starting sync for folders: $FOLDERS_TO_SYNC to Akamai NetStorage..."
 
           for folder_name in $FOLDERS_TO_SYNC; do

--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -1,14 +1,18 @@
-name: Upload Config Files and Purge Akamai Cache
+# The goal of this GitHub Actions workflow is to sync specific folders (FOLDERS_TO_SYNC) to Akamai NetStorage 1FE and purge the Akamai cache.
+name: Sync Folders to 1FE Netstorage and Purge Akamai Cache
 
 on:
   push:
     branches:
-      - main  # Trigger on push to the main branch
-    #paths:
-    #  - common-configs/**
+      - main
+    paths:
+      # Only changes made to the files in the specified folders will trigger this workflow
+      # If FOLDERS_TO_SYNC changes, we need to update these to match
+      - 'integration/**' 
+      - 'production/**'
   pull_request:
     branches:
-      - main  # Trigger on PRs targeting the main branch
+      - main  
 
 jobs:
   upload-and-purge:
@@ -18,138 +22,60 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Akamai CLI, NetStorage Module, rsync, and Prepare Credentials
+      - name: Install Tools and Prepare Credentials
         run: |
-          set -e # This setup part should be strict
-          echo "Installing Akamai CLI, modules, and rsync..."
-          # Akamai CLI and Modules
+          set -e
+          
+          # Akamai CLI and Purge Module
+          echo "Installing Akamai CLI and Purge module..."
           curl -sL https://github.com/akamai/cli/releases/download/v2.0.0/akamai-v2.0.0-linuxamd64 -o akamai
           chmod +x akamai
           sudo mv akamai /usr/local/bin/
-          akamai install netstorage
-          akamai install purge
+          akamai install purge # Only installing purge module
           
-          # Akamai API Credentials for Purge
+          # Akamai API Credentials for Purge (needed for .edgerc)
+          echo "Creating .edgerc for Akamai API access..."
           echo "[ccu]
           client_secret = ${{ secrets.AKAMAI_API_CLIENT_SECRET }}
           host = ${{ secrets.AKAMAI_API_CLIENT_HOST }}
           access_token = ${{ secrets.AKAMAI_API_CLIENT_ACCESS_TOKEN }}
           client_token = ${{ secrets.AKAMAI_API_CLIENT_CLIENT_TOKEN }}" > ~/.edgerc
 
-          # NetStorage Upload Account Credentials (for Akamai NetStorage CLI commands, rsync uses SSH key)
-          echo "[default]
-          key = ${{ secrets.AKAMAI_NS_UPLOAD_ACCOUNT_KEY }}
-          id = 1fe 
-          group = 1FE
-          host = 1fe-nsu.akamaihd.net
-          cpcode = 1800003" > ~/auth
-
           # Install rsync
-          sudo apt-get update
-          sudo apt-get install -y rsync
-          rsync --version || { echo "FATAL: rsync installation failed"; exit 1; }
+          echo "Installing rsync..."
+          sudo apt-get update -q
+          sudo apt-get install -y -q rsync
           
+          # Prepare SSH key for rsync
           echo "Setting up SSH key for rsync..."
           echo "${{ secrets.AKAMAI_NS_SSH_PRIVATE_KEY }}" > $HOME/key.pem
           chmod 600 $HOME/key.pem
-          echo "Setup complete."
+          echo "Tool setup and credential preparation complete."
 
-      # --- ONE-TIME CLEANUP STEP ---
-      # This step should be removed or commented out after successful execution.
-      - name: Perform One-Time Cleanup of Remote 'development' and 'demo' Directories
-        # This step will attempt all cleanup actions and report on them.
-        # `set +e` ensures the script continues even if some rsync/ssh commands fail for one target.
+      - name: Sync Specified Folders to NetStorage
+        env:
+          FOLDERS_TO_SYNC: "integration production" 
         run: |
-          set +e # Allow commands to fail without stopping the whole script block
-          echo "=== Starting One-Time Remote Directory Cleanup ==="
-          
-          cleanup_targets="development demo stage"
-          overall_cleanup_step_status=0 # 0 for success, 1 for critical failure
+          set -e
+          echo "Starting sync for folders: $FOLDERS_TO_SYNC to Akamai NetStorage..."
 
-          echo "Creating local empty directories for cleanup: $cleanup_targets"
-          for target_dir in $cleanup_targets; do
-            if ! mkdir -p "$target_dir"; then
-              echo "    ERROR: Failed to create local directory '$target_dir'. This is a critical local error."
-              overall_cleanup_step_status=1 # Mark critical failure
+          for folder_name in $FOLDERS_TO_SYNC; do
+            # Check if the local source directory exists to prevent rsync errors
+            if [ ! -d "$folder_name" ]; then
+              echo "WARNING: Local source directory '$folder_name' not found. Skipping sync for this folder."
+              continue 
             fi
-          done
-
-          if [ "$overall_cleanup_step_status" -ne 0 ]; then
-            echo "Halting cleanup step due to errors creating essential local directories."
-            exit "$overall_cleanup_step_status"
-          fi
-
-          echo "Attempting to empty contents of remote directories: $cleanup_targets"
-          for target_dir in $cleanup_targets; do
-            echo "  ---------------------------------------------------"
-            echo "  Processing cleanup for remote '$target_dir'..."
-            # Using -avv for detailed logs, consistent with other steps
-            rsync -avv --delete \
-              -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
-              "$target_dir/" \
-              "sshacs@1fe.rsync.upload.akamai.com:$target_dir/"
-            rsync_exit_code=$?
-            if [ $rsync_exit_code -eq 0 ]; then
-              echo "    SUCCESS: rsync successfully emptied remote '$target_dir' (or it was already empty/non-existent)."
-            elif [ $rsync_exit_code -eq 23 ] || [ $rsync_exit_code -eq 24 ]; then
-              echo "    WARNING: rsync for '$target_dir' (to empty contents) finished with code $rsync_exit_code. This often means the directory was emptied but metadata updates on deleted items failed (common) or source files vanished (less common for empty source). The directory might be usable for rmdir."
-            else
-              echo "    ERROR: rsync for '$target_dir' failed with critical exit code $rsync_exit_code. Contents may not be empty."
-              overall_cleanup_step_status=1 # Mark critical failure
-            fi
-          done
-
-          echo "  ---------------------------------------------------"
-          echo "Attempting to remove the (now hopefully empty) remote directories: $cleanup_targets"
-          for target_dir in $cleanup_targets; do
-            echo "  Attempting rmdir for remote '$target_dir'..."
-            ssh -o StrictHostKeyChecking=no -i $HOME/key.pem \
-              sshacs@1fe.rsync.upload.akamai.com \
-              "rmdir $target_dir"
-            ssh_exit_code=$?
-            if [ $ssh_exit_code -eq 0 ]; then
-              echo "    SUCCESS: Successfully removed remote directory '$target_dir'."
-            else
-              echo "    INFO: Could not remove remote directory '$target_dir' (ssh exit code $ssh_exit_code). Common reasons: it didn't exist, wasn't fully emptied by rsync, or a permission issue."
-              # Not necessarily a critical failure for this cleanup step's overall status,
-              # as emptying contents was the primary rsync goal.
-            fi
-          done
-
-          echo "  ---------------------------------------------------"
-          echo "=== One-Time Remote Directory Cleanup Attempted ==="
-          echo "IMPORTANT: Review the logs from this step carefully."
-          echo "           For all future workflow runs, this 'Perform One-Time Cleanup...' step"
-          echo "           should be REMOVED or COMMENTED OUT from your YAML file."
-          
-          if [ "$overall_cleanup_step_status" -ne 0 ]; then
-            echo "ERROR: Critical errors occurred during the rsync phase of cleanup. Please review logs."
-          fi
-          exit "$overall_cleanup_step_status" # Ensure step status reflects critical rsync errors
-
-      - name: Sync Standard Directories (integration, production) to NetStorage
-        run: |
-          set -e # Exit immediately if any command here fails (recommended for main sync)
-
-          echo "=== Starting Standard Directory Sync ==="
-          standard_sync_folders="integration production"
-
-          echo "Processing standard sync for folders: $standard_sync_folders"
-          for folder_name in $standard_sync_folders; do
-            echo "  ---------------------------------------------------"
-            echo "  Processing '$folder_name'..."
+            
+            echo "  Syncing '$folder_name/'..."
             rsync -avv --delete \
               -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
               "$folder_name/" \
               "sshacs@1fe.rsync.upload.akamai.com:$folder_name/"
-            echo "  Finished rsync for '$folder_name'."
           done
-          echo "  ---------------------------------------------------"
-          echo "=== Standard Directory Sync Reported Completion by rsync ==="
-          echo "Note: If rsync reported errors (e.g., exit code 23 for 'failed to set times'), this step may still be marked as failed by GitHub Actions due to 'set -e'."
+          echo "Sync to NetStorage complete for specified folders."
 
-      - name: Purge all assets with cache tag
+      - name: Purge Akamai Cache by Cache Tag
         run: |
           set -e
-          echo "Purging all assets with cache tag using akamai CLI..."
+          echo "Purging Akamai cache for tag '1fe'..."
           akamai purge invalidate --tag 1fe


### PR DESCRIPTION
Contributions: 

1. Clean up the YML format -  break up the installs of necessary components into their own jobs for readability and atomicity. 
2. Only run the workflow for changes made to `integration` and `production` folders 
- This workflow should only be triggered for changes made to these folders.
3. Fix the path for the sync on remote - Remote 1FE NS now has the exact mirror of the current status of github and will continue as expected. ![Screenshot 2025-05-27 at 5 26 14 PM](https://github.com/user-attachments/assets/f4b1e809-f627-4278-8f09-eb43b2995a87)
4. Provided a PR pipeline that runs with the dry run option and doesn't sync any changes to NS or do a purge.