### PR TITLE
Remove rsync --delete flag

### DIFF
--- a/.github/workflows/cdn-configs.yml
+++ b/.github/workflows/cdn-configs.yml
@@ -76,7 +76,7 @@ jobs:
             fi
             
             echo "  Syncing '$folder_name/'..."
-            rsync -avv --delete \
+            rsync -avv \
               -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
               "$folder_name/" \
               "sshacs@1fe.rsync.upload.akamai.com:$folder_name/" \
@@ -143,7 +143,7 @@ jobs:
               continue 
             fi
             
-            rsync -avvc --dry-run --delete \
+            rsync -avvc --dry-run \
               -e "ssh -o StrictHostKeyChecking=no -i $HOME/key.pem" \
               "$folder_name/" \
               "sshacs@1fe.rsync.upload.akamai.com:$folder_name/" \


### PR DESCRIPTION
I am uploading 1fe-starter-app artifacts to production bucket and do not want it to be wiped when mock-cdn-assets mirror changes